### PR TITLE
Error fix "ext/_yaml.c:4:20: fatal error: Python.h: No such file 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.1
 RUN apt-get update
-RUN apt-get install -y  python-pip
+RUN apt-get install -y  python-pip python-dev
 RUN pip install --upgrade awscli
 ADD ./Gemfile /code/Gemfile
 ADD ./Gemfile.lock /code/Gemfile.lock


### PR DESCRIPTION

Error fix "ext/_yaml.c:4:20: fatal error: Python.h: No such file or directory" appearing on step four when  RUN pip install --upgrade awscli